### PR TITLE
Background gradient and scene

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -33,16 +33,32 @@ html {
 
 body {
   font-family: var(--font-body);
-  background:
-    radial-gradient(1200px 700px at 15% 10%, rgba(124, 58, 237, 0.16), transparent 55%),
-    radial-gradient(900px 600px at 85% 15%, rgba(34, 211, 238, 0.12), transparent 60%),
-    radial-gradient(900px 700px at 60% 90%, rgba(163, 255, 18, 0.08), transparent 62%),
-    linear-gradient(180deg, var(--bg), var(--bg2));
+  /* Base fill (real "page" background). The cinematic gradient lives on a fixed
+     viewport layer below so it doesn't appear to repeat down the page. */
+  background: var(--bg);
+  position: relative;
+  isolation: isolate;
   color: var(--text);
   overflow-x: clip;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   line-height: 1.55;
+}
+
+/* Fixed full-viewport site backdrop */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background:
+    radial-gradient(1200px 700px at 15% 8%, rgba(124, 58, 237, 0.18), transparent 58%),
+    radial-gradient(980px 640px at 88% 10%, rgba(34, 211, 238, 0.14), transparent 60%),
+    radial-gradient(980px 760px at 62% 94%, rgba(163, 255, 18, 0.09), transparent 62%),
+    linear-gradient(180deg, var(--bg), var(--bg2));
+  background-repeat: no-repeat;
+  background-size: cover;
 }
 
 address {

--- a/css/responsive.css
+++ b/css/responsive.css
@@ -49,9 +49,12 @@
     --lede: clamp(1.05rem, 4.2vw, 1.2rem);
   }
 
-  body {
-    /* Keep mobile backgrounds calm + classy */
-    background: linear-gradient(180deg, var(--bg), var(--bg2));
+  /* Mobile: keep the fixed backdrop calmer + less contrasty */
+  body::before {
+    background:
+      radial-gradient(900px 560px at 20% 10%, rgba(124, 58, 237, 0.12), transparent 62%),
+      radial-gradient(900px 620px at 85% 8%, rgba(34, 211, 238, 0.09), transparent 66%),
+      linear-gradient(180deg, var(--bg), var(--bg2));
   }
 
 


### PR DESCRIPTION
Remove repeating body background gradient and fix Three.js hero scene not reloading on scroll.

The body background gradient previously repeated as content scrolled; it's now a single fixed, full-viewport backdrop. The Three.js hero scene no longer disposes itself when scrolled out of view, instead pausing and resuming to ensure it reliably reappears.

---
<a href="https://cursor.com/background-agent?bcId=bc-00283ade-3131-47e4-87d4-b8fc75e70631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-00283ade-3131-47e4-87d4-b8fc75e70631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

